### PR TITLE
Debug1

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -107,13 +107,16 @@ def reload_data(index, batch):  # 从index起始，由文件列表中加载一�
     datas = g_ref_list[index:index + batch]
     output = []
     for d in datas:
-        output.append(
-            {
-                "path": d[0],
-                "lang": d[2],
-                "text": d[3]
-            }
-        )
+        try:
+            output.append(
+                {
+                    "path": d[0],
+                    "lang": d[2],
+                    "text": d[3]
+                }
+            )
+        except IndexError:
+            pass
     return output
 
 

--- a/webui.py
+++ b/webui.py
@@ -71,7 +71,8 @@ def load_ref_list_file(path):  # 加载参考音频列表文件
         g_ref_list = list(reader)
         if g_ref_folder:  # 如果指定了参考文件目录参数，则拼接文件名
             for _ in g_ref_list:
-                _[0] = os.path.join(g_ref_folder, os.path.basename(_[0]))
+                if _:
+                    _[0] = os.path.join(g_ref_folder, os.path.basename(_[0]))
         g_ref_list_max_index = len(g_ref_list) - 1
 
 


### PR DESCRIPTION
解决了在数据集存在空行时，变量g_ref_list可能存在空时报错
![aaaaaa](https://github.com/2DIPW/GPT-SoVITS-RefAudio-Tester/assets/128007572/333a5279-e87d-4a2d-8d35-f9e290bd9e48)
解决了在数据集不够一整页时，会报错
<img width="1274" alt="微信图片_20240307231808" src="https://github.com/2DIPW/GPT-SoVITS-RefAudio-Tester/assets/128007572/14565b07-f671-4fdd-bb9a-a96f44bc90d7">
